### PR TITLE
Trying to fix pip install for python>3.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,5 +27,5 @@ setuptools.setup(
 	  'pythoncom',
       'numpy',
     ],
-    python_requires='>=3.7',
+    python_requires=">=3.7"
  )


### PR DESCRIPTION
Based on some stack overflow and random googling, I think maybe the types of quotes used for python_requires could be changed, and also there was a trailing comma that seemed out of place.